### PR TITLE
Fix image shadows clipped

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,6 +9,7 @@
     tools:context="com.qhutch.shadowimageview.MainActivity">
 
     <LinearLayout
+        android:clipChildren="false"          
         android:layout_width="wrap_content"
         android:layout_height="wrap_content">
 
@@ -32,6 +33,7 @@
     </LinearLayout>
 
     <LinearLayout
+        android:clipChildren="false"          
         android:layout_width="wrap_content"
         android:layout_height="wrap_content">
 


### PR DESCRIPTION
## Resolves #17 

Set `clipChildren` to `false` for the parent linear layout to fix the clipped shadows.